### PR TITLE
Fixed when no wsl clients exist and we get copyright exit wsl update instead of pasting out the output

### DIFF
--- a/upgrade.ps1
+++ b/upgrade.ps1
@@ -144,6 +144,7 @@ function runWSLUpdate {
             $i++
             if ($i -lt 2) {return}
             if ($_ -eq "") {return}
+            if ($_.contains("Copyright")) {return}
             if ($_.contains("Distributions")) {return}
             if ($_.contains("https://aka.ms/wslstore")) {return}
             $dist = -split "$_"


### PR DESCRIPTION
Fixed when no wsl clients exist and we get copyright exit wsl update instead of pasting out the output